### PR TITLE
Add xarray to image

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -28,5 +28,6 @@ dependencies:
   - scikit-learn
   - scipy
   - shapely
+  - xarray
   - pip:        
     - netcdftime


### PR DESCRIPTION
This commit adds xarray to the image by adding it to the environment.yml
file.

Jonathan asked for this. He'll be using the uninet image on their service. We therefore also need to upload an updated docker image from nextsim-tool/Dockerfile_uninett.